### PR TITLE
Fix a crash on exit

### DIFF
--- a/src/grisbi_app.c
+++ b/src/grisbi_app.c
@@ -433,7 +433,7 @@ static void grisbi_app_init_recent_files_menu (GrisbiApp *app)
 	}
 	if (index < conf.nb_derniers_fichiers_ouverts)
 	{
-		priv->recent_array = g_realloc (priv->recent_array, index + 1 * sizeof (gchar*));
+		priv->recent_array = g_realloc (priv->recent_array, (index + 1) * sizeof (gchar*));
 		priv->recent_array[index] = NULL;
 		conf.nb_derniers_fichiers_ouverts = index;
 	}


### PR DESCRIPTION
If some recent files are no more present then the file is removed from
the list.
The list shrink was not correctly handled and a crash occured later in
grisbi_settings_save_app_config() when the list was saved.